### PR TITLE
refactor: Ajustado o estilo do card de pedidos e histórico

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,11 +2,9 @@ import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/carrousel/carrousel_screen.dart';
-import 'package:thunderapp/screens/edit_products/edit_products_screen.dart';
 import 'package:thunderapp/screens/list_products/list_products_screen.dart';
 import 'package:thunderapp/screens/orders/orders_screen.dart';
 import 'package:thunderapp/screens/payments/payments_screen.dart';
-import 'package:thunderapp/screens/add_products/add_products_screen.dart';
 import 'package:thunderapp/screens/report/report_screen.dart';
 import 'package:thunderapp/screens/screens_index.dart';
 import 'package:thunderapp/screens/start/start_screen.dart';
@@ -64,7 +62,7 @@ class App extends StatelessWidget {
             const PaymentsScreen(),
         Screens.report: (context) => const ReportScreen(),
         Screens.listProducts: (context) =>
-            ListProductsScreen(),
+            const ListProductsScreen(),
       },
     );
   }

--- a/lib/components/forms/custom_currency_form_field.dart
+++ b/lib/components/forms/custom_currency_form_field.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_element
+
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';

--- a/lib/components/forms/custom_text_form_field.dart
+++ b/lib/components/forms/custom_text_form_field.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:get/get.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 class CustomTextFormField extends StatefulWidget {

--- a/lib/screens/add_products/add_products_controller.dart
+++ b/lib/screens/add_products/add_products_controller.dart
@@ -1,14 +1,14 @@
+// ignore_for_file: avoid_print
+
 import 'dart:convert';
 import 'dart:developer';
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunderapp/screens/add_products/add_products_repository.dart';
 import 'package:thunderapp/screens/home/home_screen_repository.dart';
-import 'package:thunderapp/shared/components/dialogs/default_alert_dialog.dart';
 import 'package:thunderapp/shared/constants/app_enums.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/models/banca_model.dart';
@@ -49,9 +49,11 @@ class AddProductsController extends GetxController {
 
   final TextEditingController _descriptionController = TextEditingController();
 
-  CurrencyTextInputFormatter currencyFormatter =
-      CurrencyTextInputFormatter(locale: 'pt-Br', symbol: 'R\$');
-
+   var currencyFormatter = CurrencyTextInputFormatter.currency(
+  locale: 'pt_BR',
+  symbol: 'R\$',
+  decimalDigits: 2,
+);
   final TextEditingController _saleController = TextEditingController();
 
   final TextEditingController _titleController = TextEditingController();

--- a/lib/screens/add_products/add_products_repository.dart
+++ b/lib/screens/add_products/add_products_repository.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get_state_manager/src/simple/get_controllers.dart';

--- a/lib/screens/add_products/components/currency_format.dart
+++ b/lib/screens/add_products/components/currency_format.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/screens/add_products/components/dropdown_qtd_add_product.dart
+++ b/lib/screens/add_products/components/dropdown_qtd_add_product.dart
@@ -39,7 +39,7 @@ class _DropDownQtdAddProductState extends State<DropDownQtdAddProduct> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: EdgeInsets.only(bottom: 4),
+              padding: const EdgeInsets.only(bottom: 4),
               child: Text(
                 'Unidade de medida',
                 style: TextStyle(

--- a/lib/screens/add_products/components/elevated_button_add_product.dart
+++ b/lib/screens/add_products/components/elevated_button_add_product.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 import 'package:thunderapp/screens/home/home_screen.dart';
-import 'package:thunderapp/screens/screens_index.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 
 import '../../../shared/components/dialogs/default_alert_dialog.dart';
@@ -41,6 +40,7 @@ class _ElevatedButtonAddProductState
             await widget.controller.validateEmptyFields(context);
             if(response) {
             showDialog(
+                // ignore: use_build_context_synchronously
                 context: context,
                 builder: ((context) =>
                     DefaultAlertDialogOneButton(
@@ -48,7 +48,7 @@ class _ElevatedButtonAddProductState
                       body:
                           'Produto cadastrado com sucesso',
                       confirmText: 'Ok',
-                      onConfirm: () => Get.offAll(() => HomeScreen()),
+                      onConfirm: () => Get.offAll(() => const HomeScreen()),
                       buttonColor: kSuccessColor,
                     )));
           }}

--- a/lib/screens/add_products/components/elevated_button_back_add_product.dart
+++ b/lib/screens/add_products/components/elevated_button_back_add_product.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_build_context_synchronously
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/add_products/add_products_controller.dart';
@@ -41,7 +43,6 @@ class _ElevatedButtonBackAddProductState
                 .validateEmptyFields(context);
 
             if (response == false) {
-              // ignore: use_build_context_synchronously
               showDialog(
                   context: context,
                   builder: (context) => DefaultAlertDialog(
@@ -54,7 +55,6 @@ class _ElevatedButtonBackAddProductState
                         confirmColor: kSuccessColor,
                       ));
             } else {
-              // ignore: use_build_context_synchronously
               showDialog(
                   context: context,
                   builder: ((context) => DefaultAlertDialog(

--- a/lib/screens/add_products/components/image_edit.dart
+++ b/lib/screens/add_products/components/image_edit.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:convert';
 
 import 'package:flutter/material.dart';

--- a/lib/screens/add_products/components/sale_infos.dart
+++ b/lib/screens/add_products/components/sale_infos.dart
@@ -8,7 +8,8 @@ import 'package:thunderapp/shared/constants/style_constants.dart';
 class SaleInfos extends StatefulWidget {
   final AddProductsController controller;
 
-  const SaleInfos(this.controller, {Key? key}) : super(key: key);
+  const SaleInfos(this.controller, {Key? key})
+      : super(key: key);
 
   @override
   State<SaleInfos> createState() => _SaleInfosState();
@@ -52,7 +53,8 @@ class _SaleInfosState extends State<SaleInfos> {
                     alignment: Alignment.center,
                     child: CustomTextFormField(
                       hintText: 'Maçã',
-                      erroStyle: const TextStyle(fontSize: 12),
+                      erroStyle:
+                          const TextStyle(fontSize: 12),
                       validatorError: (value) {
                         if (value.isEmpty) {
                           return 'Obrigatório';
@@ -60,10 +62,12 @@ class _SaleInfosState extends State<SaleInfos> {
                       },
                       onChanged: (value) {
                         setState(() {
-                          widget.controller.setDescription();
+                          widget.controller
+                              .setDescription();
                         });
                       },
-                      controller: widget.controller.descriptionController,
+                      controller: widget
+                          .controller.descriptionController,
                     ),
                   ),
                 ),
@@ -99,18 +103,20 @@ class _SaleInfosState extends State<SaleInfos> {
                     alignment: Alignment.center,
                     child: CustomTextFormField(
                       hintText: 'Fruta',
-                      erroStyle: const TextStyle(fontSize: 12),
+                      erroStyle:
+                          const TextStyle(fontSize: 12),
                       validatorError: (value) {
                         if (value.isEmpty) {
                           return 'Obrigatório';
                         }
                       },
                       onChanged: (value) {
-                         setState(() {
-                           widget.controller.setTitle();
-                         });
+                        setState(() {
+                          widget.controller.setTitle();
+                        });
                       },
-                      controller: widget.controller.titleController,
+                      controller:
+                          widget.controller.titleController,
                     ),
                   ),
                 ),
@@ -148,7 +154,8 @@ class _SaleInfosState extends State<SaleInfos> {
                   child: Container(
                     alignment: Alignment.center,
                     child: CustomTextFormFieldCurrency(
-                      erroStyle: const TextStyle(fontSize: 12),
+                      erroStyle:
+                          const TextStyle(fontSize: 12),
                       validatorError: (value) {
                         if (value.isEmpty) {
                           return 'Obrigatório';
@@ -161,14 +168,15 @@ class _SaleInfosState extends State<SaleInfos> {
                         });
                       },
                       currencyFormatter: <TextInputFormatter>[
-                        CurrencyTextInputFormatter(
-                          locale: 'pt-BR',
+                        CurrencyTextInputFormatter.currency(
+                          locale: 'pt_BR',
                           symbol: 'R\$',
                           decimalDigits: 2,
                         ),
                         LengthLimitingTextInputFormatter(9),
                       ],
-                      controller: widget.controller.saleController,
+                      controller:
+                          widget.controller.saleController,
                     ),
                   ),
                 ),

--- a/lib/screens/add_products/components/stock_add_product.dart
+++ b/lib/screens/add_products/components/stock_add_product.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 

--- a/lib/screens/edit_products/components/currency_format.dart
+++ b/lib/screens/edit_products/components/currency_format.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/screens/edit_products/components/dropdown_edit_product.dart
+++ b/lib/screens/edit_products/components/dropdown_edit_product.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/models/products_model.dart';
 import 'package:thunderapp/shared/core/models/table_products_model.dart';

--- a/lib/screens/edit_products/components/dropdown_qtd_edit_product.dart
+++ b/lib/screens/edit_products/components/dropdown_qtd_edit_product.dart
@@ -5,6 +5,7 @@ import 'package:thunderapp/shared/core/models/products_model.dart';
 import '../edit_products_controller.dart';
 import 'stock_edit_product.dart';
 
+// ignore: must_be_immutable
 class DropDownQtdEditProduct extends StatefulWidget {
   final EditProductsController controller;
   ProductsModel? model;

--- a/lib/screens/edit_products/components/elevated_button_back_add_product.dart
+++ b/lib/screens/edit_products/components/elevated_button_back_add_product.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_build_context_synchronously
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/add_products/add_products_controller.dart';
@@ -41,7 +43,6 @@ class _ElevatedButtonBackAddProductState
                 .validateEmptyFields(context);
 
             if (response == false) {
-              // ignore: use_build_context_synchronously
               showDialog(
                   context: context,
                   builder: (context) => DefaultAlertDialog(
@@ -54,7 +55,6 @@ class _ElevatedButtonBackAddProductState
                         confirmColor: kSuccessColor,
                       ));
             } else {
-              // ignore: use_build_context_synchronously
               showDialog(
                   context: context,
                   builder: ((context) => DefaultAlertDialog(

--- a/lib/screens/edit_products/components/elevated_button_edit_product.dart
+++ b/lib/screens/edit_products/components/elevated_button_edit_product.dart
@@ -1,21 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 import 'package:thunderapp/screens/edit_products/edit_products_repository.dart';
 import 'package:thunderapp/screens/home/home_screen.dart';
-import 'package:thunderapp/screens/screens_index.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
-import 'package:thunderapp/shared/core/models/products_model.dart';
-import 'package:thunderapp/shared/core/models/table_products_model.dart';
-
 import '../../../shared/components/dialogs/default_alert_dialog.dart';
 import '../edit_products_controller.dart';
 
 class ElevatedButtonEditProduct extends StatefulWidget {
   final EditProductsController controller;
 
-  const ElevatedButtonEditProduct(
-      this.controller,
+  const ElevatedButtonEditProduct(this.controller,
       {Key? key})
       : super(key: key);
 
@@ -35,6 +29,7 @@ class _ElevatedButtonEditProductState
     extends State<ElevatedButtonEditProduct> {
   @override
   Widget build(BuildContext context) {
+    // ignore: unused_local_variable
     EditProductsRepository repository =
         EditProductsRepository(); // ERRADO
     Size size = MediaQuery.of(context).size;
@@ -43,19 +38,26 @@ class _ElevatedButtonEditProductState
       height: size.height * 0.06,
       child: ElevatedButton(
         onPressed: () async {
-          final isValidForm = widget.controller.formKey.currentState!.validate();
-          if(isValidForm){
-            var response = await widget.controller.validateEmptyFields();
+          final isValidForm = widget
+              .controller.formKey.currentState!
+              .validate();
+          if (isValidForm) {
+            var response = await widget.controller
+                .validateEmptyFields();
             if (response) {
               showDialog(
-                  context: context,
-                  builder: ((context) => DefaultAlertDialogOneButton(
-                        title: 'Sucesso',
-                        body: 'Produto editado com sucesso',
-                        confirmText: 'Ok',
-                        onConfirm: () => Get.offAll(() => HomeScreen()),
-                        buttonColor: kSuccessColor,
-                      )));
+                // ignore: use_build_context_synchronously
+                context: context,
+                builder: ((context) =>
+                    DefaultAlertDialogOneButton(
+                      title: 'Sucesso',
+                      body: 'Produto editado com sucesso',
+                      confirmText: 'Ok',
+                      onConfirm: () =>
+                          Get.offAll(() => const HomeScreen()),
+                      buttonColor: kSuccessColor,
+                    )),
+              );
             }
           }
         },

--- a/lib/screens/edit_products/components/sale_infos.dart
+++ b/lib/screens/edit_products/components/sale_infos.dart
@@ -1,18 +1,18 @@
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:thunderapp/components/forms/custom_text_form_field.dart';
-import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import '../../../shared/core/models/products_model.dart';
 import '../edit_products_controller.dart';
 
+// ignore: must_be_immutable
 class SaleInfos extends StatefulWidget {
   final EditProductsController controller;
   ProductsModel? productsModel;
 
-  SaleInfos(this.controller, this.productsModel, {Key? key}) : super(key: key);
+  SaleInfos(this.controller, this.productsModel, {Key? key})
+      : super(key: key);
 
   @override
   State<SaleInfos> createState() => _SaleInfosState();
@@ -61,8 +61,10 @@ class _SaleInfosState extends State<SaleInfos> {
                   child: Container(
                     alignment: Alignment.center,
                     child: CustomTextFormField(
-                      hintText: widget.productsModel!.descricao,
-                      erroStyle: const TextStyle(fontSize: 12),
+                      hintText:
+                          widget.productsModel!.descricao,
+                      erroStyle:
+                          const TextStyle(fontSize: 12),
                       validatorError: (value) {
                         if (value.isEmpty) {
                           return 'Obrigatório';
@@ -70,10 +72,12 @@ class _SaleInfosState extends State<SaleInfos> {
                       },
                       onChanged: (value) {
                         setState(() {
-                          widget.controller.setDescription();
+                          widget.controller
+                              .setDescription();
                         });
                       },
-                      controller: widget.controller.descriptionController,
+                      controller: widget
+                          .controller.descriptionController,
                     ),
                   ),
                 ),
@@ -107,7 +111,8 @@ class _SaleInfosState extends State<SaleInfos> {
                 child: ClipPath(
                   child: CustomTextFormField(
                     hintText: widget.productsModel!.titulo,
-                    erroStyle: const TextStyle(fontSize: 12),
+                    erroStyle:
+                        const TextStyle(fontSize: 12),
                     validatorError: (value) {
                       if (value.isEmpty) {
                         return 'Obrigatório';
@@ -118,7 +123,8 @@ class _SaleInfosState extends State<SaleInfos> {
                         widget.controller.setTitle();
                       });
                     },
-                    controller: widget.controller.titleController,
+                    controller:
+                        widget.controller.titleController,
                   ),
                 ),
               ),
@@ -156,7 +162,8 @@ class _SaleInfosState extends State<SaleInfos> {
                     alignment: Alignment.center,
                     child: CustomTextFormFieldCurrency(
                       keyboardType: TextInputType.number,
-                      erroStyle: const TextStyle(fontSize: 12),
+                      erroStyle:
+                          const TextStyle(fontSize: 12),
                       validatorError: (value) {
                         if (value.isEmpty) {
                           return 'Obrigatório';
@@ -169,14 +176,15 @@ class _SaleInfosState extends State<SaleInfos> {
                         });
                       },
                       currencyFormatter: <TextInputFormatter>[
-                        CurrencyTextInputFormatter(
-                          locale: 'pt-BR',
+                        CurrencyTextInputFormatter.currency(
+                          locale: 'pt_BR',
                           symbol: 'R\$',
                           decimalDigits: 2,
                         ),
                         LengthLimitingTextInputFormatter(9),
                       ],
-                      controller: widget.controller.saleController,
+                      controller:
+                          widget.controller.saleController,
                     ),
                   ),
                 ),

--- a/lib/screens/edit_products/components/stock_edit_product.dart
+++ b/lib/screens/edit_products/components/stock_edit_product.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:thunderapp/screens/add_products/add_products_controller.dart';
 
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/models/products_model.dart';
@@ -8,6 +7,7 @@ import 'package:thunderapp/shared/core/models/products_model.dart';
 import '../../../components/forms/custom_text_form_field.dart';
 import '../edit_products_controller.dart';
 
+// ignore: must_be_immutable
 class StockEditProduct extends StatefulWidget {
   final EditProductsController controller;
   ProductsModel? model;

--- a/lib/screens/edit_products/edit_products_controller.dart
+++ b/lib/screens/edit_products/edit_products_controller.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print, unnecessary_brace_in_string_interps
+
 import 'dart:convert';
 import 'dart:developer';
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
@@ -5,7 +7,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get_state_manager/src/simple/get_controllers.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:thunderapp/screens/add_products/add_products_repository.dart';
 import 'package:thunderapp/screens/home/home_screen_repository.dart';
 import 'package:thunderapp/shared/constants/app_enums.dart';
 import 'package:thunderapp/shared/core/models/banca_model.dart';
@@ -55,9 +56,12 @@ class EditProductsController extends GetxController {
   final TextEditingController _stockController =
       TextEditingController();
 
-  CurrencyTextInputFormatter currencyFormatter =
-      CurrencyTextInputFormatter(
-          locale: 'pt-Br', symbol: 'R\$');
+  var currencyFormatter = CurrencyTextInputFormatter.currency(
+  locale: 'pt_BR',
+  symbol: 'R\$',
+  decimalDigits: 2,
+);
+
 
   final TextEditingController _saleController =
       TextEditingController();

--- a/lib/screens/edit_products/edit_products_repository.dart
+++ b/lib/screens/edit_products/edit_products_repository.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';

--- a/lib/screens/edit_products/edit_products_screen.dart
+++ b/lib/screens/edit_products/edit_products_screen.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print, unrelated_type_equality_checks
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/list_products/list_products_screen.dart';
@@ -14,6 +16,7 @@ import 'edit_products_repository.dart';
 import '../../shared/constants/app_number_constants.dart';
 import '../../shared/constants/style_constants.dart';
 
+// ignore: must_be_immutable
 class EditProductsScreen extends StatefulWidget {
   ProductsModel model;
   EditProductsRepository repository;
@@ -329,7 +332,7 @@ class _EditProductsScreenState extends State<EditProductsScreen> {
                     width: size.width,
                     height: size.height * 0.06,
                     child: OutlinedButton(
-                      onPressed: () => Get.off(() => ListProductsScreen()),
+                      onPressed: () => Get.off(() => const ListProductsScreen()),
                       style: OutlinedButton.styleFrom(
                         backgroundColor: Colors.white,
                         side:

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/components/buttons/primary_button.dart';
 import 'package:thunderapp/screens/home/home_screen_controller.dart';
@@ -137,13 +135,13 @@ class _HomeScreenState extends State<HomeScreen> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (_) => ListProductsScreen(),
+                                builder: (_) => const ListProductsScreen(),
                               ),
                             );
                           },
                         ),
                       ),
-                      SizedBox(height: 8.0),
+                      const SizedBox(height: 8.0),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [

--- a/lib/screens/home/home_screen_repository.dart
+++ b/lib/screens/home/home_screen_repository.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:developer';
 
 import 'package:dio/dio.dart';

--- a/lib/screens/list_products/components/card_products_list.dart
+++ b/lib/screens/list_products/components/card_products_list.dart
@@ -1,17 +1,16 @@
-import 'package:flutter/cupertino.dart';
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:thunderapp/screens/edit_products/edit_products_repository.dart';
 import 'package:thunderapp/screens/edit_products/edit_products_screen.dart';
-import 'package:thunderapp/screens/list_products/list_products_controller.dart';
-import 'package:thunderapp/screens/add_products/add_products_screen.dart';
 import 'package:thunderapp/screens/list_products/components/image_card_list.dart';
-import 'package:thunderapp/screens/list_products/list_products_controller.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/models/products_model.dart';
 import '../../../shared/core/models/table_products_model.dart';
 import '../list_products_repository.dart';
 
+// ignore: must_be_immutable
 class CardProductsList extends StatefulWidget {
   String userToken;
   ProductsModel model;

--- a/lib/screens/list_products/components/image_card_list.dart
+++ b/lib/screens/list_products/components/image_card_list.dart
@@ -1,9 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:thunderapp/screens/list_products/list_products_controller.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
-import 'package:thunderapp/shared/core/models/products_model.dart';
 import 'package:thunderapp/shared/core/models/table_products_model.dart';
 
 class ImageCardList extends StatefulWidget {
@@ -21,7 +18,6 @@ class _ImageCardListState extends State<ImageCardList> {
 
   @override
   Widget build(BuildContext context) {
-    Size size = MediaQuery.of(context).size;
     return FutureBuilder<int?>(
 
       future: Future.value(searchID(widget.productId, widget.tableProducts)), // Retorna uma instância de Future

--- a/lib/screens/list_products/components/total_infos.dart
+++ b/lib/screens/list_products/components/total_infos.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:thunderapp/screens/list_products/list_products_controller.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 
+// ignore: must_be_immutable
 class TotalInfos extends StatelessWidget {
   ListProductsController controller;
 

--- a/lib/screens/list_products/list_products_controller.dart
+++ b/lib/screens/list_products/list_products_controller.dart
@@ -1,17 +1,12 @@
 import 'dart:convert';
 import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:thunderapp/screens/home/home_screen_controller.dart';
 import 'package:thunderapp/screens/home/home_screen_repository.dart';
-import 'package:thunderapp/screens/add_products/add_products_repository.dart';
-import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/models/banca_model.dart';
 import 'package:thunderapp/shared/core/models/table_products_model.dart';
 import 'package:thunderapp/shared/core/user_storage.dart';
-
 import '../edit_products/edit_products_repository.dart';
 import '../list_products/components/card_products_list.dart';
 import 'list_products_repository.dart';
@@ -27,34 +22,47 @@ class ListProductsController extends GetxController {
   late String userId;
   late bool hasImage = false;
 
-  HomeScreenRepository homeRepository = HomeScreenRepository();
-  EditProductsRepository editRepository = EditProductsRepository();
-  ListProductsRepository repository = ListProductsRepository();
-  final TextEditingController _searchController = TextEditingController();
+  HomeScreenRepository homeRepository =
+      HomeScreenRepository();
+  EditProductsRepository editRepository =
+      EditProductsRepository();
+  ListProductsRepository repository =
+      ListProductsRepository();
+  final TextEditingController _searchController =
+      TextEditingController();
 
-  TextEditingController get searchController => _searchController;
+  TextEditingController get searchController =>
+      _searchController;
 
   void setHasImage(bool value) {
     hasImage = value;
     update();
   }
 
-  Future<List<CardProductsList>> populateCardsProductsList() async {
+  Future<List<CardProductsList>>
+      populateCardsProductsList() async {
     List<CardProductsList> list = [];
     UserStorage userStorage = UserStorage();
     var token = await userStorage.getUserToken();
     var userId = await userStorage.getUserId();
-    bancaModel = await homeRepository.getBancaPrefs(token, userId);
+    bancaModel =
+        await homeRepository.getBancaPrefs(token, userId);
 
-    var products = await repository.getProducts(bancaModel?.id);
+    var products =
+        await repository.getProducts(bancaModel?.id);
 
     quantProducts = products.length;
 
     if (products.isNotEmpty) {
       for (int i = 0; i < products.length; i++) {
+        // ignore: avoid_print
         print(products[i]);
-        CardProductsList card =
-            CardProductsList(token, products[i], repository, tableProducts, editRepository);
+        CardProductsList card = CardProductsList(
+            token,
+            products[i],
+            repository,
+            tableProducts,
+            editRepository);
         list.add(card);
         if (products.isNotEmpty) {
           quantStock += products[i].estoque!;
@@ -75,16 +83,16 @@ class ListProductsController extends GetxController {
     }
   }
 
-
   Future<List<TableProductsModel>> loadList() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
+    SharedPreferences prefs =
+        await SharedPreferences.getInstance();
     List<String> listaString =
         prefs.getStringList('listaProdutosTabelados') ?? [];
     return listaString
-        .map((string) => TableProductsModel.fromJson(json.decode(string)))
+        .map((string) => TableProductsModel.fromJson(
+            json.decode(string)))
         .toList();
   }
-
 
   @override
   void onInit() async {

--- a/lib/screens/list_products/list_products_repository.dart
+++ b/lib/screens/list_products/list_products_repository.dart
@@ -12,8 +12,10 @@ class ListProductsRepository {
     List<ProductsModel> stockProduct = [];
     ProductsModel product = ProductsModel();
     UserStorage userStorage = UserStorage();
+    // ignore: unused_local_variable
     String nome;
     var userToken = await userStorage.getUserToken();
+    // ignore: avoid_print
     print(id);
     var response = await dio.get(
       '$kBaseURL/bancas/$id/produtos',
@@ -74,6 +76,7 @@ class ListProductsRepository {
     if (kDebugMode) {
       print(response.statusCode);
     }
+    // ignore: avoid_print
     print(response.statusCode);
     return true;
   }

--- a/lib/screens/list_products/list_products_screen.dart
+++ b/lib/screens/list_products/list_products_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get_state_manager/src/simple/get_state.dart';
 import 'package:thunderapp/screens/add_products/add_products_screen.dart';
-import 'package:thunderapp/screens/home/home_screen.dart';
-import 'package:thunderapp/screens/home/home_screen_controller.dart';
 import 'package:thunderapp/screens/list_products/components/total_infos.dart';
 import '../../shared/constants/style_constants.dart';
 import 'list_products_controller.dart';
@@ -47,7 +45,7 @@ class ListProductsScreen extends StatelessWidget {
               Navigator.push(
                   context,
                   MaterialPageRoute(
-                      builder: (_) => AddProductsScreen()));
+                      builder: (_) => const AddProductsScreen()));
             },
             backgroundColor: kPrimaryColor,
             heroTag: 'AddListProduct',

--- a/lib/screens/my store/add_store_screen.dart
+++ b/lib/screens/my store/add_store_screen.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_unnecessary_containers, avoid_print
+
 import 'dart:math';
 
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
@@ -8,7 +10,6 @@ import 'package:thunderapp/components/buttons/primary_button.dart';
 import 'package:thunderapp/components/utils/vertical_spacer_box.dart';
 import 'package:thunderapp/screens/my%20store/my_store_controller.dart';
 import 'package:thunderapp/shared/constants/app_enums.dart';
-import 'package:thunderapp/shared/constants/app_number_constants.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import '../../components/forms/custom_text_form_field.dart';
 import '../../shared/components/dialogs/default_alert_dialog.dart';
@@ -438,11 +439,11 @@ class _AddStoreScreenState extends State<AddStoreScreen> {
                                             },
                                             hintText: "R\$ 7,00",
                                             currencyFormatter: <TextInputFormatter>[
-                                              CurrencyTextInputFormatter(
-                                                locale: 'pt-BR',
-                                                symbol: 'R\$',
-                                                decimalDigits: 2,
-                                              ),
+                                              CurrencyTextInputFormatter.currency(
+                                                  locale: 'pt_BR',
+                                                  symbol: 'R\$',
+                                                  decimalDigits: 2,
+                                                ),
                                               LengthLimitingTextInputFormatter(
                                                   8),
                                             ],

--- a/lib/screens/my store/edit_store_screen.dart
+++ b/lib/screens/my store/edit_store_screen.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:math';
 
 import 'package:currency_text_input_formatter/currency_text_input_formatter.dart';
@@ -483,11 +485,11 @@ class _EditStoreScreenState extends State<EditStoreScreen> {
                                             },
                                             hintText: "R\$ $freteCorreto",
                                             currencyFormatter: <TextInputFormatter>[
-                                              CurrencyTextInputFormatter(
-                                                locale: 'pt-BR',
-                                                symbol: 'R\$',
-                                                decimalDigits: 2,
-                                              ),
+                                              CurrencyTextInputFormatter.currency(
+                                                  locale: 'pt_BR',
+                                                  symbol: 'R\$',
+                                                  decimalDigits: 2,
+                                                ),
                                               LengthLimitingTextInputFormatter(
                                                   8),
                                             ],
@@ -550,7 +552,7 @@ class _EditStoreScreenState extends State<EditStoreScreen> {
                                 width: size.width,
                                 height: size.height * 0.06,
                                 child: OutlinedButton(
-                                  onPressed: () => Get.off(() => HomeScreen()),
+                                  onPressed: () => Get.off(() => const HomeScreen()),
                                   style: OutlinedButton.styleFrom(
                                     backgroundColor: Colors.white,
                                     side: const BorderSide(

--- a/lib/screens/my store/my_store_controller.dart
+++ b/lib/screens/my store/my_store_controller.dart
@@ -1,6 +1,7 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 import 'dart:developer';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';

--- a/lib/screens/my store/my_store_repository.dart
+++ b/lib/screens/my store/my_store_repository.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
@@ -45,6 +47,8 @@ class MyStoreRepository {
     }
 
     String? userToken = await userStorage.getUserToken();
+    // ignore: duplicate_ignore
+    // ignore: avoid_print
     print(banca.getPrecoMin);
     String precoMinimo = banca.getPrecoMin.toString();
     const find = "R\$";

--- a/lib/screens/order detail/order_detail_screen.dart
+++ b/lib/screens/order detail/order_detail_screen.dart
@@ -7,7 +7,7 @@ import 'package:thunderapp/shared/constants/app_number_constants.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 
 class OrderDetailScreen extends StatelessWidget {
-  const OrderDetailScreen({super.key});
+  const OrderDetailScreen(model, controller, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -46,124 +46,139 @@ class OrderDetailScreen extends StatelessWidget {
       ],
       appBar: AppBar(
         title: Text(
-          'Detalhe pedido #01023',
+          'Detalhes do pedido',
           style: kTitle2.copyWith(color: kPrimaryColor),
         ),
       ),
       body: Container(
-          padding: const EdgeInsets.all(
-              kDefaultPadding - kSmallSize),
-          height: size.height,
-          child: Card(
-            child: Padding(
-              padding:
-                  const EdgeInsets.all(kDefaultPadding),
-              child: Column(
-                crossAxisAlignment:
-                    CrossAxisAlignment.start,
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        'Pedido 010101',
-                        style: kBody3.copyWith(
-                            fontWeight: FontWeight.bold),
-                      ),
-                      Text(
-                        '10/10/2022',
-                        style: kCaption2.copyWith(
-                            color: kTextButtonColor),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Cliente:',
-                        style: kCaption2.copyWith(
-                            color: kTextButtonColor),
-                      ),
-                      const Text('Nome do Cliente',
-                          style: kCaption1),
-                      const SizedBox()
-                    ],
-                  ),
-                  const Divider(),
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Forma de pagamento:',
-                        style: kCaption2.copyWith(
-                            color: kTextButtonColor),
-                      ),
-                      const Text(
-                        'PIX',
-                        style: kBody2,
-                      ),
-                      IconButton(
-                          onPressed: () {},
-                          icon: const Icon(
-                            Icons.image,
-                            color: kSuccessColor,
-                          ))
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Tipo de entrega:',
-                        style: kCaption2.copyWith(
-                            color: kTextButtonColor),
-                      ),
-                      const Text(
-                        'Entrega',
-                        style: kBody2,
-                      ),
-                      const SizedBox(),
-                    ],
-                  ),
-                  const InformationHolder(),
-                  const InformationHolder(),
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Taxa de entrega',
-                        style: kCaption2.copyWith(
-                            color: kTextButtonColor),
-                      ),
-                      const Text(
-                        '7,00',
-                        style: kBody2,
-                      ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisAlignment:
-                        MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      const Text('Total do pedido',
-                          style: kBody1),
-                      Text(
-                        '7,00',
-                        style: kBody2.copyWith(
-                            color: kAlertColor),
-                      ),
-                    ],
-                  ),
-                ],
+        padding: const EdgeInsets.all(
+            kDefaultPadding - kSmallSize),
+        height: size.height,
+        child: Container(
+          decoration: BoxDecoration(
+            color:
+                Colors.white, // Cor de fundo do Container
+            borderRadius: BorderRadius.circular(
+                10), // Bordas arredondadas
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withOpacity(
+                    0.5), // Cor da sombra com transparência
+                spreadRadius: 1,
+                blurRadius: 10,
+                offset: const Offset(0, 0),
               ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Pedido 010101',
+                      style: kBody3.copyWith(
+                          fontWeight: FontWeight.bold),
+                    ),
+                    Text(
+                      '10/10/2022',
+                      style: kCaption2.copyWith(
+                          color: kTextButtonColor),
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Cliente:',
+                      style: kCaption2.copyWith(
+                          color: kTextButtonColor),
+                    ),
+                    const Text('Nome do Cliente',
+                        style: kCaption1),
+                    const SizedBox()
+                  ],
+                ),
+                const Divider(),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Forma de pagamento:',
+                      style: kCaption2.copyWith(
+                          color: kTextButtonColor),
+                    ),
+                    const Text(
+                      'PIX',
+                      style: kBody2,
+                    ),
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(
+                        Icons.image,
+                        color: kSuccessColor,
+                      ),
+                    )
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Tipo de entrega:',
+                      style: kCaption2.copyWith(
+                          color: kTextButtonColor),
+                    ),
+                    const Text(
+                      'Entrega',
+                      style: kBody2,
+                    ),
+                    const SizedBox(),
+                  ],
+                ),
+                const InformationHolder(),
+                const InformationHolder(),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Taxa de entrega',
+                      style: kCaption2.copyWith(
+                          color: kTextButtonColor),
+                    ),
+                    const Text(
+                      '7,00',
+                      style: kBody2,
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    const Text('Total do pedido',
+                        style: kBody1),
+                    Text(
+                      '7,00',
+                      style: kBody2.copyWith(
+                          color: kAlertColor),
+                    ),
+                  ],
+                ),
+              ],
             ),
-          )),
+          ),
+        ),
+      ),
     );
   }
 }
@@ -175,16 +190,16 @@ class InformationHolder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return const Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        const Text(
+        Text(
           'Endereço:',
           style: kBody3,
         ),
         Padding(
-          padding: const EdgeInsets.only(left: kHugeSize),
-          child: const Column(
+          padding: EdgeInsets.only(left: kHugeSize),
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Text('Rua professora Esmeralda Barros, 67'),

--- a/lib/screens/order_detail/order_detail_screen.dart
+++ b/lib/screens/order_detail/order_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../shared/components/dialogs/default_alert_dialog.dart';
 import '../../shared/core/models/pedido_model.dart';
 import '../orders/orders_controller.dart';
 
+// ignore: must_be_immutable
 class OrderDetailScreen extends StatefulWidget {
   PedidoModel model;
   OrdersController controller;
@@ -19,14 +20,179 @@ class OrderDetailScreen extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<OrderDetailScreen> createState() => _OrderDetailScreenState();
+  State<OrderDetailScreen> createState() =>
+      _OrderDetailScreenState();
 }
 
-class _OrderDetailScreenState extends State<OrderDetailScreen> {
+class _OrderDetailScreenState
+    extends State<OrderDetailScreen> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
     return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Detalhe pedido #0${widget.model.id}',
+          style: kTitle2.copyWith(color: kPrimaryColor),
+        ),
+      ),
+      body: Container(
+        padding: const EdgeInsets.all(
+            kDefaultPadding - kSmallSize),
+        height: size.height,
+        child: Card(
+          child: Padding(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: ListView(
+              children: <Widget>[
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Pedido #${widget.model.id.toString()}',
+                      style: TextStyle(
+                          fontSize: size.height * 0.018),
+                    ),
+                    Text(
+                      widget.model.dataPedido.toString(),
+                      style: TextStyle(
+                          fontSize: size.height * 0.018,
+                          fontWeight: FontWeight.w500),
+                    ),
+                  ],
+                ),
+                Divider(
+                  height: size.height * 0.01,
+                  color: Colors.transparent,
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      'Cliente:',
+                      style: TextStyle(
+                          fontSize: size.height * 0.022,
+                          color: kTextButtonColor),
+                    ),
+                    const Padding(
+                      padding: EdgeInsetsDirectional.only(
+                          start: 10),
+                      // child: Text(widget.model.consumidorId.toString(),
+                      //     style: TextStyle(fontSize: size.height * 0.018, fontWeight: FontWeight.w700),),
+                    ),
+                    const SizedBox()
+                  ],
+                ),
+                Divider(
+                  height: size.height * 0.03,
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Forma de pagamento:',
+                      style: TextStyle(
+                          fontSize: size.height * 0.018,
+                          color: kTextButtonColor),
+                    ),
+                    // Text(
+                    //   widget.model.tipoPagamentoId.toString(),
+                    //   style: TextStyle(fontSize: size.height * 0.018),
+                    // ),
+                    IconButton(
+                        onPressed: () {},
+                        icon: const Icon(
+                          Icons.image,
+                          color: kPrimaryColor,
+                        ))
+                  ],
+                ),
+                Divider(
+                  height: size.height * 0.01,
+                  color: Colors.transparent,
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Tipo de entrega:',
+                      style: TextStyle(
+                          fontSize: size.height * 0.018,
+                          color: kTextButtonColor),
+                    ),
+                    Text(
+                      widget.model.tipoEntrega.toString(),
+                      style: TextStyle(
+                          fontSize: size.height * 0.018),
+                    ),
+                  ],
+                ),
+                Divider(
+                  height: size.height * 0.02,
+                  color: Colors.transparent,
+                ),
+                const InformationHolder(),
+                Divider(
+                  height: size.height * 0.02,
+                  color: Colors.transparent,
+                ),
+                const ItensOrder(),
+                Divider(
+                  height: size.height * 0.03,
+                  color: Colors.transparent,
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Taxa de entrega',
+                      style: TextStyle(
+                          fontSize: size.height * 0.018),
+                    ),
+                    Text(
+                      NumberFormat.simpleCurrency(
+                              locale: 'pt-BR',
+                              decimalDigits: 2)
+                          .format(widget.model.taxaEntrega),
+                      style: TextStyle(
+                          fontSize: size.height * 0.018),
+                    ),
+                  ],
+                ),
+                Divider(
+                  height: size.height * 0.015,
+                  color: Colors.transparent,
+                ),
+                Row(
+                  mainAxisAlignment:
+                      MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      'Total do pedido',
+                      style: TextStyle(
+                          fontSize: size.height * 0.018),
+                    ),
+                    Text(
+                      NumberFormat.simpleCurrency(
+                              locale: 'pt-BR',
+                              decimalDigits: 2)
+                          .format(widget.model.subtotal),
+                      style: TextStyle(
+                          fontSize: size.height * 0.018,
+                          color: kPrimaryColor),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
       persistentFooterButtons: [
         SizedBox(
           child: Column(
@@ -38,57 +204,70 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
               Text(
                 'Confirmar pedido?',
                 style: TextStyle(
-                    fontWeight: FontWeight.w500, fontSize: size.height * 0.020),
+                    fontWeight: FontWeight.w500,
+                    fontSize: size.height * 0.020),
               ),
               Divider(
                 height: size.height * 0.015,
                 color: Colors.transparent,
               ),
               Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                mainAxisAlignment:
+                    MainAxisAlignment.spaceAround,
                 children: <Widget>[
                   SizedBox(
                     width: 168,
                     child: PrimaryButton(
-                        text: 'Confirmar',
-                        onPressed: () {
-                          showDialog(
-                              context: context,
-                              builder: (context) => DefaultAlertDialog(
-                                title: 'Confirmar',
-                                body: 'Você tem certeza que deseja aceitar o pedido?',
-                                confirmText: 'Sim',
-                                cancelText: 'Não',
-                                onConfirm: () {
-                                  widget.controller.setConfirm(true);
-                                  widget.controller
-                                      .confirmOrder(context, widget.model.id!);
-                                },
-                                confirmColor: kSuccessColor,
-                                cancelColor: kErrorColor,
-                              ));
-                        }),
+                      text: 'Confirmar',
+                      onPressed: () {
+                        showDialog(
+                          context: context,
+                          builder: (context) =>
+                              DefaultAlertDialog(
+                            title: 'Confirmar',
+                            body:
+                                'Você tem certeza que deseja aceitar o pedido?',
+                            confirmText: 'Sim',
+                            cancelText: 'Não',
+                            onConfirm: () {
+                              widget.controller
+                                  .setConfirm(true);
+                              widget.controller
+                                  .confirmOrder(context,
+                                      widget.model.id!);
+                            },
+                            confirmColor: kSuccessColor,
+                            cancelColor: kErrorColor,
+                          ),
+                        );
+                      },
+                    ),
                   ),
                   SizedBox(
                     width: 168,
                     child: CancelButton(
-                        text: 'Cancelar',
-                        onPressed: () {
-                          showDialog(
-                              context: context,
-                              builder: (context) => DefaultAlertDialog(
-                                title: 'Recusar',
-                                body: 'Você tem certeza que deseja recusar o pedido?',
-                                confirmText: 'Sim',
-                                cancelText: 'Não',
-                                onConfirm: () {
-                                  widget.controller
-                                      .confirmOrder(context, widget.model.id!);
-                                },
-                                confirmColor: kSuccessColor,
-                                cancelColor: kErrorColor,
-                              ));
-                        }),
+                      text: 'Cancelar',
+                      onPressed: () {
+                        showDialog(
+                          context: context,
+                          builder: (context) =>
+                              DefaultAlertDialog(
+                            title: 'Recusar',
+                            body:
+                                'Você tem certeza que deseja recusar o pedido?',
+                            confirmText: 'Sim',
+                            cancelText: 'Não',
+                            onConfirm: () {
+                              widget.controller
+                                  .confirmOrder(context,
+                                      widget.model.id!);
+                            },
+                            confirmColor: kSuccessColor,
+                            cancelColor: kErrorColor,
+                          ),
+                        );
+                      },
+                    ),
                   )
                 ],
               )
@@ -96,151 +275,6 @@ class _OrderDetailScreenState extends State<OrderDetailScreen> {
           ),
         )
       ],
-      appBar: AppBar(
-        title: Text(
-          'Detalhe pedido #0${widget.model.id}',
-          style: kTitle2.copyWith(color: kPrimaryColor),
-        ),
-      ),
-      body: Container(
-          padding: const EdgeInsets.all(kDefaultPadding - kSmallSize),
-          height: size.height,
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.all(kDefaultPadding),
-              child: ListView(
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        'Pedido #${widget.model.id.toString()}',
-                        style: TextStyle(fontSize: size.height * 0.018),
-                      ),
-                      Text(
-                        widget.model.dataPedido.toString(),
-                        style: TextStyle(
-                            fontSize: size.height * 0.018,
-                            fontWeight: FontWeight.w500),
-                      ),
-                    ],
-                  ),
-                  Divider(
-                    height: size.height * 0.01,
-                    color: Colors.transparent,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        'Cliente:',
-                        style: TextStyle(
-                            fontSize: size.height * 0.022,
-                            color: kTextButtonColor),
-                      ),
-                      const Padding(
-                        padding: EdgeInsetsDirectional.only(start: 10),
-                        // child: Text(widget.model.consumidorId.toString(),
-                        //     style: TextStyle(fontSize: size.height * 0.018, fontWeight: FontWeight.w700),),
-                      ),
-                      const SizedBox()
-                    ],
-                  ),
-                  Divider(
-                    height: size.height * 0.03,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Forma de pagamento:',
-                        style: TextStyle(
-                            fontSize: size.height * 0.018,
-                            color: kTextButtonColor),
-                      ),
-                      // Text(
-                      //   widget.model.tipoPagamentoId.toString(),
-                      //   style: TextStyle(fontSize: size.height * 0.018),
-                      // ),
-                      IconButton(
-                          onPressed: () {},
-                          icon: const Icon(
-                            Icons.image,
-                            color: kPrimaryColor,
-                          ))
-                    ],
-                  ),
-                  Divider(
-                    height: size.height * 0.01,
-                    color: Colors.transparent,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Tipo de entrega:',
-                        style: TextStyle(
-                            fontSize: size.height * 0.018,
-                            color: kTextButtonColor),
-                      ),
-                      Text(
-                        widget.model.tipoEntrega.toString(),
-                        style: TextStyle(fontSize: size.height * 0.018),
-                      ),
-                    ],
-                  ),
-                  Divider(
-                    height: size.height * 0.02,
-                    color: Colors.transparent,
-                  ),
-                  const InformationHolder(),
-                  Divider(
-                    height: size.height * 0.02,
-                    color: Colors.transparent,
-                  ),
-                  const ItensOrder(),
-                  Divider(
-                    height: size.height * 0.03,
-                    color: Colors.transparent,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        'Taxa de entrega',
-                        style: TextStyle(fontSize: size.height * 0.018),
-                      ),
-                      Text(
-                        NumberFormat.simpleCurrency(
-                                locale: 'pt-BR', decimalDigits: 2)
-                            .format(widget.model.taxaEntrega),
-                        style: TextStyle(fontSize: size.height * 0.018),
-                      ),
-                    ],
-                  ),
-                  Divider(
-                    height: size.height * 0.015,
-                    color: Colors.transparent,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text('Total do pedido',
-                          style: TextStyle(fontSize: size.height * 0.018)),
-                      Text(
-                        NumberFormat.simpleCurrency(
-                                locale: 'pt-BR', decimalDigits: 2)
-                            .format(widget.model.subtotal),
-                        style: TextStyle(
-                            fontSize: size.height * 0.018,
-                            color: kPrimaryColor),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          )),
     );
   }
 }
@@ -251,10 +285,12 @@ class InformationHolder extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<InformationHolder> createState() => _InformationHolderState();
+  State<InformationHolder> createState() =>
+      _InformationHolderState();
 }
 
-class _InformationHolderState extends State<InformationHolder> {
+class _InformationHolderState
+    extends State<InformationHolder> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
@@ -266,18 +302,22 @@ class _InformationHolderState extends State<InformationHolder> {
           style: TextStyle(fontSize: size.height * 0.018),
         ),
         Padding(
-          padding: EdgeInsets.only(left: kHugeSize),
+          padding: const EdgeInsets.only(left: kHugeSize),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Text('Rua professora Esmeralda Barros, 67',
-                  style: TextStyle(fontSize: size.height * 0.018)),
+                  style: TextStyle(
+                      fontSize: size.height * 0.018)),
               Text('Boa Vista',
-                  style: TextStyle(fontSize: size.height * 0.018)),
+                  style: TextStyle(
+                      fontSize: size.height * 0.018)),
               Text('Apartamento',
-                  style: TextStyle(fontSize: size.height * 0.018)),
+                  style: TextStyle(
+                      fontSize: size.height * 0.018)),
               Text('Contato: (81) 99699-7476',
-                  style: TextStyle(fontSize: size.height * 0.018)),
+                  style: TextStyle(
+                      fontSize: size.height * 0.018)),
             ],
           ),
         )

--- a/lib/screens/orders/orders_controller.dart
+++ b/lib/screens/orders/orders_controller.dart
@@ -1,35 +1,33 @@
-import 'dart:developer';
+// ignore_for_file: avoid_print, use_build_context_synchronously
 
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:get/get_core/src/get_main.dart';
-import 'package:get/get_rx/get_rx.dart';
-import 'package:get/get_state_manager/src/simple/get_controllers.dart';
 import 'package:thunderapp/screens/home/home_screen_repository.dart';
 import 'package:thunderapp/screens/orders/orders_repository.dart';
 import 'package:thunderapp/screens/orders/orders_screen.dart';
 import 'package:thunderapp/shared/core/models/banca_model.dart';
 import 'package:thunderapp/shared/core/models/pedido_model.dart';
-
+import 'package:thunderapp/shared/core/models/user_model.dart';
 import '../../shared/components/dialogs/default_alert_dialog.dart';
 import '../../shared/constants/style_constants.dart';
 import '../../shared/core/user_storage.dart';
 import '../home/home_screen.dart';
-import '../screens_index.dart';
 
 class OrdersController extends GetxController {
   RxString statusOrder = ''.obs;
   int quantPedidos = 0;
   BancaModel? bancaModel;
   PedidoModel? pedidoModel;
-  HomeScreenRepository homeRepository = HomeScreenRepository();
+  HomeScreenRepository homeRepository =
+      HomeScreenRepository();
   List<PedidoModel> orders = [];
   List<OrderCard> pedidos = [];
   late Future<List<dynamic>> orderData;
   OrdersRepository repository = OrdersRepository();
   bool confirmSucess = false;
   bool confirmedOrder = false;
-
+  Rx<User> user = User().obs;
   List<PedidoModel> get getOrders => orders;
 
   void setConfirm(bool value) {
@@ -44,19 +42,22 @@ class OrdersController extends GetxController {
 
   void confirmOrder(BuildContext context, int id) async {
     try {
-      confirmSucess = await repository.confirmOrder(id, confirmedOrder);
+      confirmSucess =
+          await repository.confirmOrder(id, confirmedOrder);
       if (confirmSucess && confirmedOrder == true) {
-        // ignore: use_build_context_synchronously
         showDialog(
             context: context,
-            builder: (context) => DefaultAlertDialogOneButton(
+            builder: (context) =>
+                DefaultAlertDialogOneButton(
                   title: 'Sucesso',
                   body: 'O pedido foi aceito',
                   confirmText: 'Ok',
                   onConfirm: () {
                     navigator?.pushAndRemoveUntil(
-                      MaterialPageRoute(builder: (context)=>HomeScreen()),
-                          (Route<dynamic> route) => false,
+                      MaterialPageRoute(
+                          builder: (context) =>
+                              const HomeScreen()),
+                      (Route<dynamic> route) => false,
                     );
                   },
                   buttonColor: kSuccessColor,
@@ -64,14 +65,17 @@ class OrdersController extends GetxController {
       } else {
         showDialog(
             context: context,
-            builder: (context) => DefaultAlertDialogOneButton(
+            builder: (context) =>
+                DefaultAlertDialogOneButton(
                   title: 'Sucesso',
                   body: 'O pedido foi negado',
                   confirmText: 'Ok',
                   onConfirm: () {
                     navigator?.pushAndRemoveUntil(
-                      MaterialPageRoute(builder: (context)=>HomeScreen()),
-                          (Route<dynamic> route) => false,
+                      MaterialPageRoute(
+                          builder: (context) =>
+                              const HomeScreen()),
+                      (Route<dynamic> route) => false,
                     );
                   },
                   buttonColor: kSuccessColor,
@@ -81,8 +85,8 @@ class OrdersController extends GetxController {
       Get.dialog(
         AlertDialog(
           title: const Text('Erro'),
-          content:
-              Text("${e.toString()}\n Procure o suporte com a equipe LMTS"),
+          content: Text(
+              "${e.toString()}\n Procure o suporte com a equipe LMTS"),
           actions: [
             TextButton(
               child: const Text('Voltar'),
@@ -101,7 +105,8 @@ class OrdersController extends GetxController {
     UserStorage userStorage = UserStorage();
     var token = await userStorage.getUserToken();
     var userId = await userStorage.getUserId();
-    bancaModel = await homeRepository.getBancaPrefs(token, userId);
+    bancaModel =
+        await homeRepository.getBancaPrefs(token, userId);
     var pedidos = await repository.getOrders();
 
     quantPedidos = pedidos.length;
@@ -110,7 +115,8 @@ class OrdersController extends GetxController {
       if (pedidos[i].status != "pedido recusado" &&
           pedidos[i].status != "pagamento expirado" &&
           pedidos[i].status != "pedido entregue") {
-        OrderCard card = OrderCard(pedidos[i], OrdersController());
+        OrderCard card =
+            OrderCard(pedidos[i], OrdersController());
         list.add(card);
       }
     }
@@ -131,4 +137,19 @@ class OrdersController extends GetxController {
     super.onInit();
     update();
   }
+
+  Future<String> fetchUserDetails(int userId) async {
+  try {
+    var userDetails = await repository.fetchUserDetails(userId);
+    if (userDetails != null && userDetails.containsKey('user')) {
+      return userDetails['user']['name'];  // Retorna apenas o nome do usuário
+    } else {
+      return "Nome não encontrado"; // Retorna uma mensagem padrão
+    }
+  } catch (e) {
+    print('Erro ao buscar nome do usuário: $e');
+    return "Erro ao buscar usuário"; // Retorna uma mensagem de erro
+  }
+}
+
 }

--- a/lib/screens/orders/orders_repository.dart
+++ b/lib/screens/orders/orders_repository.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
@@ -5,7 +8,6 @@ import 'package:dio/dio.dart';
 import 'package:get/get_state_manager/src/simple/get_controllers.dart';
 
 import 'package:thunderapp/shared/core/models/pedido_model.dart';
-import 'package:thunderapp/shared/core/models/produto_pedido_model.dart';
 import '../../shared/constants/app_text_constants.dart';
 import '../../shared/core/user_storage.dart';
 
@@ -160,6 +162,35 @@ class OrdersRepository extends GetxController {
         }
       }
       return false;
+    }
+  }
+
+  Future<Map<String, dynamic>?> fetchUserDetails(int userId) async {
+    UserStorage userStorage = UserStorage();
+    userToken = await userStorage.getUserToken();
+
+    try {
+      Response response = await _dio.get(
+        '$kBaseURL/users/$userId', // Modifique o URL conforme a estrutura da sua API
+        options: Options(
+          headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": "Bearer $userToken"
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        // Decodificar a resposta JSON e retornar o objeto de usuário
+        return jsonDecode(response.data);
+      } else {
+        print('Erro ao buscar detalhes do usuário: ${response.statusCode}');
+        return null;
+      }
+    } catch (e) {
+      print('Erro ao fazer a chamada de API: $e');
+      return null;
     }
   }
 }

--- a/lib/screens/orders/orders_screen.dart
+++ b/lib/screens/orders/orders_screen.dart
@@ -1,9 +1,9 @@
+
 import 'package:flutter/material.dart';
 import 'package:get/get_state_manager/src/simple/get_state.dart';
 import 'package:thunderapp/components/utils/vertical_spacer_box.dart';
 import 'package:thunderapp/screens/order_detail/order_detail_screen.dart';
 import 'package:thunderapp/screens/orders/orders_controller.dart';
-import 'package:thunderapp/screens/orders/orders_repository.dart';
 import 'package:thunderapp/shared/constants/app_enums.dart';
 import 'package:thunderapp/shared/constants/app_number_constants.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
@@ -42,6 +42,7 @@ class _OrdersScreenState extends State<OrdersScreen> {
   }
 }
 
+// ignore: must_be_immutable
 class OrderCard extends StatefulWidget {
   PedidoModel model;
   OrdersController controller;
@@ -67,122 +68,137 @@ class _OrderCardState extends State<OrderCard> {
             return OrderDetailScreen(widget.model, widget.controller);
           })),
           child: Ink(
-            child: Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(5),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(kDefaultPadding),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Column(
-                          children: [
-                            SizedBox(
-                              width: size.width * 0.4,
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: [
-                                  Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        'Pedido #${widget.model.id.toString()}',
-                                        style: kBody3.copyWith(
-                                            fontWeight: FontWeight.bold),
-                                      ),
-                                      Divider(
-                                        height: size.height * 0.006,
-                                        color: Colors.transparent,
-                                      ),
-                                      Text(
-                                        'Cliente',
-                                        style:
-                                            kCaption2.copyWith(color: kTextButtonColor),
-                                      ),
-                                    ],
-                                  ),
-                                  // Text(widget.model.consumidorId.toString(),
-                                  //     style: kCaption1),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                        IconButton(
-                            onPressed: () {
-                              Navigator.push(context, MaterialPageRoute(builder: (context) {
-                                return OrderDetailScreen(widget.model, widget.controller);
-                              }),);
-                            },
-                            icon: Icon(
-                              Icons.more_vert,
-                              color: kPrimaryColor,
-                              size: size.height * 0.05,
-                            )),
-                      ],
-                    ),
-                    const Divider(),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Text(
-                          'Itens:',
-                          style: kCaption2.copyWith(color: kTextButtonColor),
-                        ),
-                        Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.total))
-                      ],
-                    ),
-                    const VerticalSpacerBox(size: SpacerSize.medium),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Text(
-                          'Taxa de entrega:',
-                          style: kCaption2.copyWith(color: kTextButtonColor),
-                        ),
-                        Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.taxaEntrega))
-                      ],
-                    ),
-                    const VerticalSpacerBox(size: SpacerSize.medium),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        const Text(
-                          'Total do pedido:',
-                          style: kBody2,
-                        ),
-                        Text(
-                          NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.subtotal),
-                          style: kBody2.copyWith(color: kDetailColor),
-                        )
-                      ],
-                    ),
-                    const VerticalSpacerBox(size: SpacerSize.large),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Text(
-                          widget.model.dataPedido.toString(),
-                          style: kCaption2.copyWith(color: kTextButtonColor),
-                        ),
-                        Container(
-                          padding: const EdgeInsets.all(kTinySize),
-                          decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(5),
-                              color: kAlertColor),
-                          child: Text(
-                            widget.model.status.toString(),
-                            style: kCaption2.copyWith(color: kBackgroundColor),
-                          ),
-                        )
-                      ],
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.white, // Cor de fundo do Container
+                  borderRadius: BorderRadius.circular(10), // Bordas arredondadas
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.grey.withOpacity(0.5), // Cor da sombra com transparência
+                      spreadRadius: 1,
+                      blurRadius: 10,
+                      offset: const Offset(0, 0),
                     ),
                   ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(kDefaultPaddingCardPedido),
+                  child: Column(
+                    
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Column(
+                            children: [
+                              SizedBox(
+                                width: size.width * 0.4,
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: [
+                                    Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          'Pedido #${widget.model.id.toString()}',
+                                          style: kBody3.copyWith(
+                                              fontWeight: FontWeight.bold),
+                                        ),
+                                        Divider(
+                                          height: size.height * 0.006,
+                                          color: Colors.transparent,
+                                        ),
+                                        Text(
+                                          'Cliente',
+                                          style:
+                                              kCaption2.copyWith(color: kTextButtonColor),
+                                        ),
+                                      ],
+                                    ),
+                                    const Text("",
+                                      // widget.controller.fetchUserDetails(widget.model.consumidorId),
+                                        style: kCaption1),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          IconButton(
+                              onPressed: () {
+                                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                                  return OrderDetailScreen(widget.model, widget.controller);
+                                }),);
+                              },
+                              icon: Icon(
+                                Icons.more_vert,
+                                color: kPrimaryColor,
+                                size: size.height * 0.05,
+                              )),
+                        ],
+                      ),
+                      const Divider(),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            'Itens:',
+                            style: kCaption2.copyWith(color: kTextButtonColor),
+                          ),
+                          Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.total))
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.medium),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            'Taxa de entrega:',
+                            style: kCaption2.copyWith(color: kTextButtonColor),
+                          ),
+                          Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.taxaEntrega))
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.medium),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          const Text(
+                            'Total do pedido:',
+                            style: kBody2,
+                          ),
+                          Text(
+                            NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.subtotal),
+                            style: kBody2.copyWith(color: kDetailColor),
+                          )
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.large),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            DateFormat('dd/MM/yyyy').format(widget.model.dataPedido!),
+                            style:
+                            kCaption2.copyWith(color: kTextButtonColor, fontSize: 16, ),
+                          ),
+                          Container(
+                            padding: const EdgeInsets.all(kTinySize),
+                            decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(5),
+                                color: kAlertColor),
+                            child: Text(
+                              widget.model.status.toString(),
+                              style: kCaption2.copyWith(color: kBackgroundColor),
+                            ),
+                          )
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/report/report_controller.dart
+++ b/lib/screens/report/report_controller.dart
@@ -13,7 +13,8 @@ import 'report_screen.dart';
 class ReportController extends GetxController {
   int quantPedidos = 0;
   BancaModel? bancaModel;
-  HomeScreenRepository homeRepository = HomeScreenRepository();
+  HomeScreenRepository homeRepository =
+      HomeScreenRepository();
   List<PedidoModel> orders = [];
   List<ReportCard> pedidos = [];
   late Future<List<dynamic>> orderData;
@@ -26,14 +27,16 @@ class ReportController extends GetxController {
     UserStorage userStorage = UserStorage();
     var token = await userStorage.getUserToken();
     var userId = await userStorage.getUserId();
-    bancaModel = await homeRepository.getBancaPrefs(token, userId);
+    bancaModel =
+        await homeRepository.getBancaPrefs(token, userId);
     var pedidos = await repository.getReports();
 
     quantPedidos = pedidos.length;
 
     for (int i = 0; i < pedidos.length; i++) {
       if (pedidos[i].status != "aguardando confirmação") {
-        ReportCard card = ReportCard(pedidos[i]);
+        ReportCard card =
+            ReportCard(pedidos[i], ReportController());
         list.add(card);
       }
     }

--- a/lib/screens/report/report_screen.dart
+++ b/lib/screens/report/report_screen.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get_state_manager/src/simple/get_state.dart';
 import 'package:intl/intl.dart';
 import 'package:thunderapp/components/utils/vertical_spacer_box.dart';
-
-import 'package:thunderapp/screens/orders/orders_controller.dart';
+import 'package:thunderapp/screens/order%20detail/order_detail_screen.dart';
 import 'package:thunderapp/screens/report/report_controller.dart';
-
 import 'package:thunderapp/shared/constants/app_enums.dart';
 import 'package:thunderapp/shared/constants/app_number_constants.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
@@ -32,7 +30,8 @@ class _ReportScreenState extends State<ReportScreen> {
           ),
         ),
         body: Container(
-          padding: const EdgeInsets.all(kDefaultPadding - kSmallSize),
+          padding: const EdgeInsets.all(
+              kDefaultPadding - kSmallSize),
           height: size.height,
           child: ListView(
             children: controller.pedidos,
@@ -43,11 +42,13 @@ class _ReportScreenState extends State<ReportScreen> {
   }
 }
 
+// ignore: must_be_immutable
 class ReportCard extends StatefulWidget {
   PedidoModel model;
-
+  ReportController controller;
   ReportCard(
-    this.model, {
+    this.model,
+    this.controller, {
     Key? key,
   }) : super(key: key);
 
@@ -61,124 +62,149 @@ class _ReportCardState extends State<ReportCard> {
     Size size = MediaQuery.of(context).size;
     return Column(
       children: [
-        Card(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(5),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(kDefaultPadding),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Column(
-                      children: [
-                        SizedBox(
-                          width: size.width * 0.4,
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            crossAxisAlignment: CrossAxisAlignment.end,
+        InkWell(
+          onTap: () =>
+            Navigator.push(context, MaterialPageRoute(builder: (context) {
+            return OrderDetailScreen(widget.model, widget.controller);
+          })),
+          child: Ink(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.white, // Cor de fundo do Container
+                  borderRadius: BorderRadius.circular(10), // Bordas arredondadas
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.grey.withOpacity(0.5), // Cor da sombra com transparência
+                      spreadRadius: 1,
+                      blurRadius: 10,
+                      offset: const Offset(0, 0),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(kDefaultPaddingCardPedido),
+                  child: Column(
+                    
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Column(
                             children: [
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Pedido #${widget.model.id.toString()}',
-                                    style: kBody3.copyWith(
-                                        fontWeight: FontWeight.bold),
-                                  ),
-                                  Divider(
-                                    height: size.height * 0.006,
-                                    color: Colors.transparent,
-                                  ),
-                                  Text(
-                                    'Cliente',
-                                    style: kCaption2.copyWith(
-                                        color: kTextButtonColor),
-                                  ),
-                                ],
+                              SizedBox(
+                                width: size.width * 0.4,
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: [
+                                    Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          'Pedido #${widget.model.id.toString()}',
+                                          style: kBody3.copyWith(
+                                              fontWeight: FontWeight.bold),
+                                        ),
+                                        Divider(
+                                          height: size.height * 0.006,
+                                          color: Colors.transparent,
+                                        ),
+                                        Text(
+                                          'Cliente',
+                                          style:
+                                              kCaption2.copyWith(color: kTextButtonColor),
+                                        ),
+                                      ],
+                                    ),
+                                    const Text("",
+                                      // widget.controller.fetchUserDetails(widget.model.consumidorId),
+                                        style: kCaption1),
+                                  ],
+                                ),
                               ),
-                              // Text(widget.model.consumidorId.toString(),
-                              //     style: kCaption1),
                             ],
                           ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-                const Divider(),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      'Itens:',
-                      style: kCaption2.copyWith(color: kTextButtonColor),
-                    ),
-                    Text(NumberFormat.simpleCurrency(
-                            locale: 'pt-BR', decimalDigits: 2)
-                        .format(widget.model.total)),
-                  ],
-                ),
-                const VerticalSpacerBox(size: SpacerSize.medium),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      'Taxa de entrega:',
-                      style: kCaption2.copyWith(color: kTextButtonColor),
-                    ),
-                    Text(NumberFormat.simpleCurrency(
-                            locale: 'pt-BR', decimalDigits: 2)
-                        .format(widget.model.taxaEntrega)),
-                  ],
-                ),
-                const VerticalSpacerBox(size: SpacerSize.medium),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    const Text(
-                      'Total do pedido:',
-                      style: kBody2,
-                    ),
-                    Text(
-                      NumberFormat.simpleCurrency(
-                              locale: 'pt-BR', decimalDigits: 2)
-                          .format(widget.model.subtotal),
-                      style: kBody2.copyWith(color: kDetailColor),
-                    ),
-                  ],
-                ),
-                const VerticalSpacerBox(size: SpacerSize.large),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      widget.model.dataPedido.toString(),
-                      style: kCaption2.copyWith(color: kTextButtonColor),
-                    ),
-                    Container(
-                      padding: const EdgeInsets.all(kTinySize),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(5),
-                          color: kAlertColor),
-                      child: Text(
-                        widget.model.status.toString(),
-                        style: kCaption2.copyWith(color: kBackgroundColor),
+                          IconButton(
+                              onPressed: () {
+                                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                                  return OrderDetailScreen(widget.model, widget.controller);
+                                }),);
+                              },
+                              icon: Icon(
+                                Icons.more_vert,
+                                color: kPrimaryColor,
+                                size: size.height * 0.05,
+                              )),
+                        ],
                       ),
-                    )
-                  ],
+                      const Divider(),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            'Itens:',
+                            style: kCaption2.copyWith(color: kTextButtonColor),
+                          ),
+                          Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.total))
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.medium),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            'Taxa de entrega:',
+                            style: kCaption2.copyWith(color: kTextButtonColor),
+                          ),
+                          Text(NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.taxaEntrega))
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.medium),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          const Text(
+                            'Total do pedido:',
+                            style: kBody2,
+                          ),
+                          Text(
+                            NumberFormat.simpleCurrency(locale:'pt-BR', decimalDigits: 2).format(widget.model.subtotal),
+                            style: kBody2.copyWith(color: kDetailColor),
+                          )
+                        ],
+                      ),
+                      const VerticalSpacerBox(size: SpacerSize.large),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            DateFormat('dd/MM/yyyy').format(widget.model.dataPedido!),
+                            style:
+                            kCaption2.copyWith(color: kTextButtonColor, fontSize: 16, ),
+                          ),
+                          Container(
+                            padding: const EdgeInsets.all(kTinySize),
+                            decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(5),
+                                color: kAlertColor),
+                            child: Text(
+                              widget.model.status.toString(),
+                              style: kCaption2.copyWith(color: kBackgroundColor),
+                            ),
+                          )
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
-              ],
+              ),
             ),
           ),
         ),
-        Divider(
-          height: size.height * 0.01,
-          color: Colors.transparent,
-        ),
+        Divider(height: size.height * 0.01, color: Colors.transparent,),
       ],
     );
   }

--- a/lib/screens/signin/sign_in_controller.dart
+++ b/lib/screens/signin/sign_in_controller.dart
@@ -1,4 +1,6 @@
 
+// ignore_for_file: use_build_context_synchronously
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/screens_index.dart';
@@ -45,7 +47,6 @@ class SignInController with ChangeNotifier {
         notifyListeners();
 
 
-          // ignore: use_build_context_synchronously
           Navigator.pushReplacementNamed(
             context, Screens.home);
 
@@ -54,7 +55,6 @@ class SignInController with ChangeNotifier {
       else if (succ == 2) {
 
 
-        // ignore: use_build_context_synchronously
         Navigator.pushReplacementNamed(context, Screens.addStore);
       }
       else{

--- a/lib/screens/signin/sign_in_repository.dart
+++ b/lib/screens/signin/sign_in_repository.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:developer';
 
 import 'package:dio/dio.dart';

--- a/lib/screens/signin/sign_in_screen.dart
+++ b/lib/screens/signin/sign_in_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:thunderapp/components/buttons/primary_button.dart';
 import 'package:thunderapp/components/forms/custom_text_form_field.dart';
 import 'package:thunderapp/components/utils/vertical_spacer_box.dart';
 import 'package:thunderapp/screens/signin/sign_in_controller.dart';
@@ -56,7 +55,7 @@ class SignInScreen extends StatelessWidget {
                                       EdgeInsets.only(top: size.height * 0.03),
                                   padding: const EdgeInsets.only(
                                       top: 30, left: 28, bottom: 0, right: 28),
-                                  decoration: BoxDecoration(
+                                  decoration: const BoxDecoration(
                                       color: kBackgroundColor,
                                       borderRadius: BorderRadius.only(
                                           topLeft: Radius.circular(15),

--- a/lib/screens/start/start_controller.dart
+++ b/lib/screens/start/start_controller.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:thunderapp/screens/start/start_repository.dart';
@@ -15,8 +17,8 @@ class StartController extends GetxController {
   String? userId;
   String userName = 'teste';
 
-  Future StartVeri(BuildContext context) async {
-    var succ = await startRepository.Start(
+  Future startVeri(BuildContext context) async {
+    var succ = await startRepository.start(
         userToken = await userStorage.getUserToken(),
         userId = await userStorage.getUserId(),
     );

--- a/lib/screens/start/start_repository.dart
+++ b/lib/screens/start/start_repository.dart
@@ -1,15 +1,14 @@
+// ignore_for_file: avoid_print
+
 import 'dart:developer';
-
 import 'package:dio/dio.dart';
-import 'package:thunderapp/shared/core/models/banca_model.dart';
-
 import '../../shared/constants/app_text_constants.dart';
 
 class StartRepository {
   final Dio _dio = Dio();
   int vazia = 5;
 
-  Future<int?> Start(
+  Future<int?> start(
       String? userToken, String? userId) async {
     print('userId: $userId');
     print('chegou aqui');

--- a/lib/screens/start/start_screen.dart
+++ b/lib/screens/start/start_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:thunderapp/components/buttons/custom_text_button.dart';
 import 'package:thunderapp/components/buttons/primary_button.dart';
 import 'package:thunderapp/components/buttons/secondary_button.dart';
-
 import 'package:thunderapp/components/utils/vertical_spacer_box.dart';
 import 'package:thunderapp/screens/screens_index.dart';
 import 'package:thunderapp/screens/signin/sign_in_controller.dart';
@@ -11,12 +9,9 @@ import 'package:thunderapp/screens/start/start_controller.dart';
 import 'package:thunderapp/shared/constants/app_number_constants.dart';
 import 'package:thunderapp/shared/constants/style_constants.dart';
 import 'package:thunderapp/shared/core/navigator.dart';
-
 import '../../shared/constants/app_enums.dart';
 
 class StartScreen extends StatelessWidget {
-
-
   const StartScreen({Key? key}) : super(key: key);
 
   @override
@@ -63,7 +58,8 @@ class StartScreen extends StatelessWidget {
                     topLeft: Radius.circular(30),
                     topRight: Radius.circular(30),
                     bottomLeft: Radius.zero,
-                    bottomRight: Radius.zero,),
+                    bottomRight: Radius.zero,
+                  ),
                 ),
                 child: Column(
                   mainAxisAlignment:
@@ -71,7 +67,8 @@ class StartScreen extends StatelessWidget {
                   children: <Widget>[
                     Text(
                       'Para começar, que tal entrar na sua conta?',
-                      style: kTitle2.copyWith(fontSize: size.height * 0.028),
+                      style: kTitle2.copyWith(
+                          fontSize: size.height * 0.028),
                       textAlign: TextAlign.center,
                     ),
                     const VerticalSpacerBox(
@@ -82,7 +79,8 @@ class StartScreen extends StatelessWidget {
                         : PrimaryButton(
                             text:
                                 'Continuar como ${controller.userName}',
-                            onPressed: () => controller.StartVeri(context)),
+                            onPressed: () => controller
+                                .startVeri(context)),
                     SizedBox(
                       width: size.width,
                       child: Column(
@@ -100,16 +98,16 @@ class StartScreen extends StatelessWidget {
                           const VerticalSpacerBox(
                               size: SpacerSize.small),
                           SecondaryButton(
-                              text:
-                                  'Não sou ${controller.userName}',
-                              onPressed: () {
-                                navigatorKey.currentState!
-                                    .pushReplacementNamed(
-                                        Screens.signin);
-                              }),
+                            text:
+                                'Não sou ${controller.userName}',
+                            onPressed: () {
+                              navigatorKey.currentState!
+                                  .pushReplacementNamed(
+                                      Screens.signin);
+                            },
+                          ),
                           const VerticalSpacerBox(
                               size: SpacerSize.small),
-                        
                         ],
                       ),
                     ),

--- a/lib/shared/constants/app_number_constants.dart
+++ b/lib/shared/constants/app_number_constants.dart
@@ -1,5 +1,5 @@
 const double kDefaultPadding = 32.0;
-
+const double kDefaultPaddingCardPedido = 17.0;
 
 const double kDefaultBorderRadius = 8.0;
 

--- a/lib/shared/constants/app_text_constants.dart
+++ b/lib/shared/constants/app_text_constants.dart
@@ -5,5 +5,5 @@
 ///the text should be in the following format: start the variable with the letter 'K' and then
 ///use camel case to separate the words
 const String kPppTitle = 'Vida Agroecológica Vendedor';
-//const String kBaseURL = 'http://127.0.0.1:8000/api';
+// const String kBaseURL = 'http://172.20.144.1:8000/api';
 const String kBaseURL = 'https://comerciovidaagroecologica.ufape.edu.br/api';

--- a/lib/shared/core/image_picker_controller.dart
+++ b/lib/shared/core/image_picker_controller.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 import 'dart:math';
 import 'package:file_picker/file_picker.dart';

--- a/lib/shared/core/models/item_model.dart
+++ b/lib/shared/core/models/item_model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 class ItemModel {
     String created_at;
     int id;

--- a/lib/shared/core/models/pedido_model.dart
+++ b/lib/shared/core/models/pedido_model.dart
@@ -1,4 +1,3 @@
-import 'package:thunderapp/shared/core/models/produto_pedido_model.dart';
 
 class PedidoModel {
   int? id;
@@ -14,7 +13,7 @@ class PedidoModel {
   DateTime? dataEnvio;
   DateTime? dataEntrega;
   int? formaPagamentoId;
-  int? consumidorId;
+  int consumidorId;
   int? bancaId;
 
   PedidoModel(
@@ -31,7 +30,7 @@ class PedidoModel {
       this.dataEnvio,
       this.dataEntrega,
       this.formaPagamentoId,
-      this.consumidorId,
+      required this.consumidorId,
       this.bancaId});
 
   factory PedidoModel.fromJson(Map<String, dynamic> json) {

--- a/lib/shared/core/models/transacoes_model.dart
+++ b/lib/shared/core/models/transacoes_model.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:thunderapp/shared/core/models/item_model.dart';
 
 class TransacoesModel {

--- a/lib/shared/core/models/user_model.dart
+++ b/lib/shared/core/models/user_model.dart
@@ -1,0 +1,17 @@
+class User {
+  int? id;
+  String? name;
+  String? email;
+  // outros campos...
+
+  User({this.id, this.name, this.email});
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      id: json['id'],
+      name: json['name'],
+      email: json['email'],
+      // inicialize os outros campos a partir de json...
+    );
+  }
+}


### PR DESCRIPTION
# Relatório de Modificações:

## order_screen.dart:
- Ajustado o estilo do Card de pedidos

## report_screen.dart:
- Ajustado o estilo do Card de pedidos no histórico

## Screenshots:

<div style="display: flex; justify-content: space-around;">
  <img src="https://github.com/lmtsufape/vida-agroecologica-app-comercio-vendedor/assets/109475692/e6816496-1923-4079-883d-1506834551b0" width="25%" />
  <img src="https://github.com/lmtsufape/vida-agroecologica-app-comercio-vendedor/assets/109475692/1ec2d320-afe1-4f5a-ab17-ed624b5ca5b6" width="25%" />
</div>


## Modificações adicionais:
- Correção da utilização do metodo:

![image](https://github.com/lmtsufape/vida-agroecologica-app-comercio-vendedor/assets/109475692/bc2d38c8-6b90-4204-bb4e-4f5d9fe6d5d6)

- E correções do tipo, adicionar const, indentação, remover dependências desnecessárias ou não utilizadas e ignorar o uso de print em vários arquivos.