### PR TITLE
Correção de erros do local notifications

### DIFF
--- a/lib/shared/core/features/notifications/notifications_manager.dart
+++ b/lib/shared/core/features/notifications/notifications_manager.dart
@@ -1,4 +1,4 @@
-import 'dart:developer';
+/*import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -68,3 +68,4 @@ class NotificationManager {
     return pendingNotificationRequests;
   }
 }
+*/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,6 @@ dependencies:
   lottie: ^1.4.3
   bot_toast: ^4.0.3
   rate_my_app: ^1.1.3
-  flutter_local_notifications: ^11.0.1
   flutter_svg: ^1.1.5
   file: ^6.1.4
   timezone: ^0.9.0


### PR DESCRIPTION
O arquivo que usa o local notification foi comentado por completo pois no momento não há necessidade para que ele esteja ativo no projeto, depois será necessário mudar uma parte do código pois como a versão do flutter foi alterado há alguns erros a serem corrigidos nesse mesmo arquivo que foi comentado