### PR TITLE
Adicionar persistência de e-mail no login com ShartedPreferences - le…

### DIFF
--- a/lib/screens/signin/sign_in_controller.dart
+++ b/lib/screens/signin/sign_in_controller.dart
@@ -2,8 +2,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thunderapp/screens/screens_index.dart';
-
 import '../../shared/components/dialogs/default_alert_dialog.dart';
 import '../../shared/constants/style_constants.dart';
 import 'sign_in_repository.dart';
@@ -17,18 +17,47 @@ enum SignInStatus {
 
 class SignInController with ChangeNotifier {
   final SignInRepository _repository = SignInRepository();
-  String? email;
-  String? password;
+  String? errorMessage;
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
-  String? errorMessage;
   GlobalKey<FormState> formKey = GlobalKey<FormState>();
-
-  TextEditingController get emailController => _emailController;
-
-  TextEditingController get passwordController => _passwordController;
   var status = SignInStatus.idle;
 
+  // Getters for controllers
+  TextEditingController get emailController => _emailController;
+  TextEditingController get passwordController => _passwordController;
+
+  // Constructor to load saved email on initialization
+  SignInController() {
+    loadSavedEmail();
+  }
+
+  // Save email to SharedPreferences
+  Future<void> saveEmail(String email) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('userEmail', email);
+  }
+
+  // Load email from SharedPreferences
+  Future<void> loadSavedEmail() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedEmail = prefs.getString('userEmail');
+    if (savedEmail != null) {
+      _emailController.text = savedEmail;
+      notifyListeners();
+    }
+  }
+
+  // Set error message with delay for reset
+  void setErrorMessage(String value) async {
+    errorMessage = value;
+    notifyListeners();
+    await Future.delayed(const Duration(seconds: 2));
+    errorMessage = null;
+    notifyListeners();
+  }
+
+  // Sign-in method
   void signIn(BuildContext context) async {
     try {
       status = SignInStatus.loading;
@@ -38,52 +67,50 @@ class SignInController with ChangeNotifier {
         email: _emailController.text,
         password: _passwordController.text,
       );
-      if (succ == 1) {
+
+      if (succ == 1 || succ == 2) {
+        // Save email on successful login
+        await saveEmail(_emailController.text);
+
         status = SignInStatus.done;
         notifyListeners();
-        Navigator.pushReplacementNamed(context, Screens.home);
-      } else if (succ == 2) {
-        Navigator.pushReplacementNamed(context, Screens.addStore);
+
+        Navigator.pushReplacementNamed(
+          context,
+          succ == 1 ? Screens.home : Screens.addStore,
+        );
       } else if (succ == 3) {
         showDialog(
-            context: context,
-            builder: (context) => DefaultAlertDialogOneButton(
-                  title: 'Erro',
-                  body: 'Você não possui autorização para entrar no aplicativo, fale com o(a) presidente!',
-                  confirmText: 'Voltar',
-                  onConfirm: () => Get.back(),
-                  buttonColor: kErrorColor,
-                ));
+          context: context,
+          builder: (context) => DefaultAlertDialogOneButton(
+            title: 'Erro',
+            body: 'Você não possui autorização para entrar no aplicativo, fale com o(a) presidente!',
+            confirmText: 'Voltar',
+            onConfirm: () => Get.back(),
+            buttonColor: kErrorColor,
+          ),
+        );
         status = SignInStatus.error;
-        setErrorMessage(
-            'Você não possui autorização para entrar no aplicativo, fale com o(a) presidente!');
+        setErrorMessage('Você não possui autorização para entrar no aplicativo.');
       } else {
         showDialog(
-            context: context,
-            builder: (context) => DefaultAlertDialogOneButton(
-                  title: 'Erro',
-                  body: 'Credenciais inválidas, verifique seus dados',
-                  confirmText: 'Voltar',
-                  onConfirm: () => Get.back(),
-                  buttonColor: kErrorColor,
-                ));
+          context: context,
+          builder: (context) => DefaultAlertDialogOneButton(
+            title: 'Erro',
+            body: 'Credenciais inválidas, verifique seus dados',
+            confirmText: 'Voltar',
+            onConfirm: () => Get.back(),
+            buttonColor: kErrorColor,
+          ),
+        );
         status = SignInStatus.error;
-        setErrorMessage('Credenciais inválidas, verifique seus dados');
-        notifyListeners();
+        setErrorMessage('Credenciais inválidas, verifique seus dados.');
       }
       notifyListeners();
     } catch (e) {
       status = SignInStatus.error;
-      setErrorMessage('Credenciais inválidas verifique seus dados');
+      setErrorMessage('Credenciais inválidas, verifique seus dados.');
       notifyListeners();
     }
-  }
-
-  void setErrorMessage(String value) async {
-    errorMessage = value;
-    notifyListeners();
-    await Future.delayed(const Duration(seconds: 2));
-    errorMessage = null;
-    notifyListeners();
   }
 }


### PR DESCRIPTION
Esta Pull Request implementa a funcionalidade de persistência do e-mail na tela de login utilizando o pacote SharedPreferences. Com essa alteração, o e-mail do usuário será salvo localmente no dispositivo após o primeiro login e será automaticamente preenchido na próxima vez que o usuário acessar a tela de login.

Alterações principais:

 - Adição da lógica de armazenamento e recuperação do e-mail usando SharedPreferences.
 - Atualização do SignInController para gerenciar o processo de salvar e recuperar o e-mail.
 - Ajustes na tela de login para preencher automaticamente o campo de e-mail com o valor salvo (se disponível).
 - Motivação: Esta melhoria visa proporcionar uma experiência de login mais fluida, economizando tempo ao preencher 
   automaticamente o e-mail do usuário nas visitas subsequentes à tela de login.

Impacto:

 - O usuário não precisará digitar o e-mail toda vez que acessar o aplicativo.
 - O comportamento da tela de login foi ajustado para carregar o e-mail salvo na primeira vez que o app for aberto.


![image](https://github.com/user-attachments/assets/6ed3be50-043b-4579-b33b-5386e0911871)
